### PR TITLE
Rendition-named segment filenames for all named renditions

### DIFF
--- a/app.js
+++ b/app.js
@@ -161,10 +161,7 @@ async function processSegment(ctx, timeline, time, requestedFilename) {
   const segment = timeline.find((el) => el.segment === segmentNum);
 
   const ext = path.extname(requestedFilename);
-  const baseName = path.basename(requestedFilename, ext);
-  const namedMatch = baseName.match(/^seg-[a-zA-Z]\w*-(\d+)$/);
-  const plainMatch = baseName.match(/^seg-(\d+)$/);
-  const requestedSegNum = namedMatch ? parseInt(namedMatch[1]) : plainMatch ? parseInt(plainMatch[1]) : NaN;
+  const { segment: requestedSegNum } = extractRenditionFromSegment(path.basename(requestedFilename));
   const NUM_SEGMENTS = 5;
   const filename = isNaN(requestedSegNum)
     ? `seg-1${ext}`

--- a/app.js
+++ b/app.js
@@ -42,8 +42,7 @@ app.use(async ctx => {
           outputError(ctx, renditionError);
         } else {
           const mediaLength = calculateMediaLength(spec.operations);
-          const hasSegmentError = renditionName && !!spec.renditionErrors.segment[renditionName];
-          await generateRendition(ctx, mediaLength, renditionName, hasSegmentError);
+          await generateRendition(ctx, mediaLength, renditionName);
         }
         break;
       }
@@ -112,7 +111,7 @@ function generateMediaPlaylist(ctx, spec) {
   outputString(ctx, 'application/x-mpegURL', playlist);
 }
 
-function generateRendition(ctx, medialength, renditionName, hasSegmentError) {
+function generateRendition(ctx, medialength, renditionName) {
   const start =
 `#EXTM3U
 #EXT-X-VERSION:7
@@ -125,7 +124,7 @@ function generateRendition(ctx, medialength, renditionName, hasSegmentError) {
   let segments = '';
 
   for (let i = 0; i < medialength / segmentLength; i++) {
-    const segFile = hasSegmentError ? `rendition-${renditionName}-seg-${i+1}.m4s` : `seg-${i+1}.m4s`;
+    const segFile = renditionName ? `seg-${renditionName}-${i+1}.m4s` : `seg-${i+1}.m4s`;
     segments +=
 `\n#EXTINF:6.006,
 ${segFile}`;
@@ -163,8 +162,9 @@ async function processSegment(ctx, timeline, time, requestedFilename) {
 
   const ext = path.extname(requestedFilename);
   const baseName = path.basename(requestedFilename, ext);
-  const segMatch = baseName.match(/^seg-(\d+)$/);
-  const requestedSegNum = segMatch ? parseInt(segMatch[1]) : NaN;
+  const namedMatch = baseName.match(/^seg-[a-zA-Z]\w*-(\d+)$/);
+  const plainMatch = baseName.match(/^seg-(\d+)$/);
+  const requestedSegNum = namedMatch ? parseInt(namedMatch[1]) : plainMatch ? parseInt(plainMatch[1]) : NaN;
   const NUM_SEGMENTS = 5;
   const filename = isNaN(requestedSegNum)
     ? `seg-1${ext}`

--- a/docs/prd/multiple-renditions.md
+++ b/docs/prd/multiple-renditions.md
@@ -17,3 +17,7 @@ Scenarios developers would like to test (with this and additional tools):
 - How the player ABR behavior behaves when thoughput can support higher or lower renditions
 - Player behavior when a rendition can't be downloaded or returns an error
 - Events are fired correctly as renditions change
+
+## Specifications
+
+- Segment filenames in the manifests should denote the bandwidth of the rendition. For example, the 400000 rendition should have a filename like: seg-high-1.m4s. The actual files coming from the disk will be seg-X.m4s but they would be re-written as served to the player.

--- a/docs/tdd/multiple-renditions.md
+++ b/docs/tdd/multiple-renditions.md
@@ -60,7 +60,7 @@ The current server simulates one rendition. Real ABR players choose from multipl
 
 **Bandwidth throttle** is global — all segment delivery is throttled to the specified kbps. The player measures throughput and its ABR algorithm selects the appropriate rendition. Delay ops take precedence over bandwidth throttle when both apply.
 
-All renditions share the same segment URL namespace (`0.ts`, `1.ts`, etc.) — there are no per-rendition segment paths.
+**Rendition-named segment filenames** — every named rendition's playlist uses segment filenames that include the rendition name (e.g., `rendition-low-seg-1.m4s`). This lets the server always identify which rendition a segment request belongs to. Single-rendition and unnamed renditions continue to use plain `seg-{n}.m4s` filenames.
 
 ---
 
@@ -85,9 +85,22 @@ rendition-high.m3u8
 
 ### HLS Rendition Playlists
 
-`/spec/rendition-low.m3u8`, `/spec/rendition-mid.m3u8`, etc. — each returns a VOD playlist with shared segment numbers. Returns an HTTP error if that rendition has a matching `renditionErrors` entry.
+`/spec/rendition-low.m3u8`, `/spec/rendition-mid.m3u8`, etc. — each returns a VOD playlist. Named renditions use rendition-named segment filenames:
 
-`rendition.m3u8` remains valid for single-rendition inline specs (backward compatibility).
+```
+#EXTM3U
+...
+#EXTINF:6.006,
+seg-low-1.m4s
+#EXTINF:6.006,
+seg-low-2.m4s
+...
+#EXT-X-ENDLIST
+```
+
+Returns an HTTP error if that rendition has a matching `renditionErrors` entry.
+
+`rendition.m3u8` (single-rendition) continues to use plain `seg-{n}.m4s` filenames.
 
 ### DASH Manifest
 
@@ -129,13 +142,15 @@ rendition-high.m3u8
 - `resolveRenditions(spec)` — normalizes renditions array; no per-rendition operations merging
 - `resolveRenditionErrors(operations)` — scans ops for `error` entries with `rendition` field; returns `{ name: code }` map
 - `createSegmentTimeline()` — skips rendition-targeted ops; handles `bandwidth` op
+- `calculateElapsedPlayheadTime()` — must handle both `rendition-{name}-seg-{n}.m4s` and plain `seg-{n}.m4s`; extract segment number from either format
 
 ### `app.js`
 
 - `loadSpecification()` — returns `{ operations, renditions, renditionErrors }`; global ops filter excludes rendition-targeted errors
 - `generateMediaPlaylist()` — uses `rendition-${r.name}.m3u8` for named renditions, `rendition-${i}.m3u8` fallback
+- `generateRendition()` — always uses `seg-${renditionName}-${i+1}.m4s` when a rendition name is present; plain `seg-${i+1}.m4s` for unnamed/single-rendition. Removes `hasSegmentError` special-casing.
 - Rendition case — `extractRenditionName(filename)` lookup in `spec.renditionErrors`; returns HTTP error if found
-- `processSegment()` — reverse-scans timeline for active `bandwidthKbps`; passes to `outputFile()`
+- `processSegment()` — reverse-scans timeline for active `bandwidthKbps`; passes to `outputFile()`; segment number extraction must handle both `rendition-{name}-seg-{n}.m4s` and plain `seg-{n}.m4s`
 - `outputFile()` — added `bandwidthKbps` param; throttles at `kbps * 1000 / 8 / 10` bytes per 100ms when no delay active
 - `generateDashMPD()` — uses `r.name` for representation ID when available
 

--- a/lib/logic.js
+++ b/lib/logic.js
@@ -56,9 +56,9 @@ function resolveRenditionErrors(operations) {
 }
 
 function extractRenditionFromSegment(filename) {
-  const match = filename.match(/^rendition-(\w+)-seg-(\d+)\.m4s$/);
-  if (match) {
-    return { rendition: match[1], segment: parseInt(match[2]) };
+  const named = filename.match(/^seg-([a-zA-Z]\w*)-(\d+)\.m4s$/);
+  if (named) {
+    return { rendition: named[1], segment: parseInt(named[2]) };
   }
   const plain = filename.match(/^seg-(\d+)\.m4s$/);
   if (plain) {
@@ -175,10 +175,11 @@ function calculateElapsedPlayheadTime(filename) {
   if (!filename) return;
 
   const baseName = path.basename(filename, path.extname(filename));
-  const match = baseName.match(/^seg-(\d+)$/);
-  if (!match) return;
+  const named = baseName.match(/^seg-[a-zA-Z]\w*-(\d+)$/);
+  if (named) return (parseInt(named[1]) - 1) * segmentLength;
 
-  return (parseInt(match[1]) - 1) * segmentLength;
+  const plain = baseName.match(/^seg-(\d+)$/);
+  if (plain) return (parseInt(plain[1]) - 1) * segmentLength;
 }
 
 function opDuration(op) {

--- a/lib/logic.test.js
+++ b/lib/logic.test.js
@@ -141,14 +141,14 @@ describe('resolveRenditionErrors', () => {
 });
 
 describe('extractRenditionFromSegment', () => {
-  it('returns rendition and segment for rendition-low-seg-1.m4s', () => {
-    assert.deepEqual(extractRenditionFromSegment('rendition-low-seg-1.m4s'), { rendition: 'low', segment: 1 });
+  it('returns rendition and segment for seg-low-1.m4s', () => {
+    assert.deepEqual(extractRenditionFromSegment('seg-low-1.m4s'), { rendition: 'low', segment: 1 });
   });
-  it('returns rendition and segment for rendition-high-seg-5.m4s', () => {
-    assert.deepEqual(extractRenditionFromSegment('rendition-high-seg-5.m4s'), { rendition: 'high', segment: 5 });
+  it('returns rendition and segment for seg-high-5.m4s', () => {
+    assert.deepEqual(extractRenditionFromSegment('seg-high-5.m4s'), { rendition: 'high', segment: 5 });
   });
-  it('returns rendition and segment for rendition-mid-seg-2.m4s', () => {
-    assert.deepEqual(extractRenditionFromSegment('rendition-mid-seg-2.m4s'), { rendition: 'mid', segment: 2 });
+  it('returns rendition and segment for seg-mid-2.m4s', () => {
+    assert.deepEqual(extractRenditionFromSegment('seg-mid-2.m4s'), { rendition: 'mid', segment: 2 });
   });
   it('returns null rendition for plain seg-1.m4s', () => {
     assert.deepEqual(extractRenditionFromSegment('seg-1.m4s'), { rendition: null, segment: 1 });
@@ -259,6 +259,12 @@ describe('calculateElapsedPlayheadTime', () => {
   });
   it('returns 36.036 for seg-7.m4s', () => {
     assert.equal(calculateElapsedPlayheadTime('seg-7.m4s'), 36.036);
+  });
+  it('returns 0 for seg-low-1.m4s', () => {
+    assert.equal(calculateElapsedPlayheadTime('seg-low-1.m4s'), 0);
+  });
+  it('returns 12.012 for seg-high-3.m4s', () => {
+    assert.equal(calculateElapsedPlayheadTime('seg-high-3.m4s'), 12.012);
   });
   it('returns undefined for non-matching filename', () => {
     assert.equal(calculateElapsedPlayheadTime('other.m4s'), undefined);

--- a/notes/features/multiple-renditions.md
+++ b/notes/features/multiple-renditions.md
@@ -1,0 +1,41 @@
+# Notes: Multiple Renditions — Rendition-Named Segments
+
+## What Changed in the PRD
+
+New spec added: segment filenames in rendition playlists must include the rendition
+name, so the server can always identify which rendition a segment request belongs to.
+
+## Decision
+
+- Named renditions → `seg-{name}-{n}.m4s` (always, not just when segment error exists)
+- Unnamed / single-rendition → `seg-{n}.m4s` (no change)
+- DASH manifest unchanged — uses SegmentTemplate with `seg-$Number$.m4s`
+
+## Root Cause of the Bug
+
+`generateRendition` only used rendition-named filenames when `hasSegmentError` was true.
+Result: `low` rendition (no error) used plain `seg-{n}.m4s`, while `mid`/`high` (with
+`"on": "segment"` errors) used `rendition-mid-seg-{n}.m4s`.
+
+## Files to Change
+
+### `app.js`
+- `generateRendition(ctx, mediaLength, renditionName, hasSegmentError)`:
+  - Remove `hasSegmentError` parameter
+  - Always use `seg-${renditionName}-${i+1}.m4s` when `renditionName` is set
+- Rendition case in router: remove `hasSegmentError` from `generateRendition` call
+
+### `lib/logic.js`
+- `calculateElapsedPlayheadTime(filename)`:
+  - Currently only matches `seg-{n}.m4s`
+  - Must also match `rendition-{name}-seg-{n}.m4s` to extract segment number
+
+### `processSegment` in `app.js`
+- `segMatch` regex only handles `seg-{n}` basename
+  - Must also parse `rendition-{name}-seg-{n}.m4s` to get segment number
+
+## Tests to Add / Update
+- `calculateElapsedPlayheadTime` — add cases for `rendition-low-seg-3.m4s`
+- `extractRenditionFromSegment` — already handles the format, no change needed
+- App-level: rendition playlist for named rendition uses rendition-named segment filenames
+- App-level: rendition playlist for unnamed rendition uses plain segment filenames


### PR DESCRIPTION
## Summary

- Named rendition playlists now always use `seg-{name}-{n}.m4s` filenames (e.g., `seg-low-1.m4s`) instead of plain `seg-{n}.m4s`
- Previously, named filenames were only used when a rendition had a segment error configured — meaning the server couldn't identify the originating rendition for error-free renditions
- Single-rendition and unnamed renditions continue to use plain `seg-{n}.m4s`

## Changes

- `generateRendition`: always emit `seg-{name}-{n}.m4s` for named renditions; remove `hasSegmentError` param
- `extractRenditionFromSegment`: parse new `seg-{name}-{n}.m4s` format (letter-leading name distinguishes from plain `seg-{n}.m4s`)
- `calculateElapsedPlayheadTime`: handle `seg-{name}-{n}.m4s` in addition to plain format
- `processSegment`: refactored to reuse `extractRenditionFromSegment` instead of duplicating regex logic
- PRD, TDD, and feature notes updated

## Test plan

- [ ] `npm test` passes (83 tests)
- [ ] Load `abr-rendition-fallback` spec — all three rendition playlists (`low`, `mid`, `high`) use `seg-{name}-{n}.m4s` filenames
- [ ] Load a single-rendition inline spec (e.g., `p30-e`) — segments remain as plain `seg-{n}.m4s`
- [ ] Segment errors still fire correctly for renditions with `"on": "segment"` errors