### PR TITLE
Error operations on a rendition should fit in time timeline

### DIFF
--- a/app.js
+++ b/app.js
@@ -54,10 +54,13 @@ app.use(async ctx => {
       }
       case 'segment': {
         console.log('Segment request');
-        const { rendition: segRendition } = extractRenditionFromSegment(filename);
+        const { rendition: segRendition, segment: segNum } = extractRenditionFromSegment(filename);
         if (segRendition && spec.renditionErrors.segment[segRendition]) {
-          outputError(ctx, spec.renditionErrors.segment[segRendition]);
-          break;
+          const err = spec.renditionErrors.segment[segRendition];
+          if (segNum >= err.activateAtSegment) {
+            outputError(ctx, err.code);
+            break;
+          }
         }
         if (!timelineCache[filepath]) {
             timelineCache[filepath] = createSegmentTimeline(spec.operations);
@@ -90,7 +93,7 @@ async function loadSpecification(filepath) {
   try {
     const contents = await fs.promises.readFile(specFile, 'utf8');
     const json = JSON.parse(contents);
-    const operations = (json.operations || []).filter(op => !op.rendition);
+    const operations = json.operations || [];
     const renditionErrors = resolveRenditionErrors(json.operations);
     return { operations, renditions: resolveRenditions(json), renditionErrors };
   } catch {

--- a/app.test.js
+++ b/app.test.js
@@ -213,17 +213,23 @@ describe('loadSpecification', () => {
 
   it('resolves rendition errors from abr-example', async () => {
     const spec = await loadSpecification('/abr-example');
-    assert.deepEqual(spec.renditionErrors, { playlist: { mid: 404 }, segment: { low: 404 } });
+    assert.deepEqual(spec.renditionErrors, {
+      playlist: {},
+      segment: {
+        mid: { code: 404, activateAtSegment: 4 },
+        low: { code: 404, activateAtSegment: 6 },
+      },
+    });
   });
 
   it('resolves segment rendition errors from abr-rendition-segment-error', async () => {
     const spec = await loadSpecification('/abr-rendition-segment-error');
-    assert.deepEqual(spec.renditionErrors, { playlist: {}, segment: { low: 503 } });
+    assert.deepEqual(spec.renditionErrors, { playlist: {}, segment: { low: { code: 503, activateAtSegment: 6 } } });
   });
 
-  it('global operations exclude rendition-targeted error ops', async () => {
+  it('operations includes rendition-targeted error ops for media length calculation', async () => {
     const spec = await loadSpecification('/abr-example');
     const hasRenditionOp = spec.operations.some(op => op.rendition);
-    assert.equal(hasRenditionOp, false);
+    assert.equal(hasRenditionOp, true);
   });
 });

--- a/lib/logic.js
+++ b/lib/logic.js
@@ -42,14 +42,19 @@ function resolveRenditionErrors(operations) {
   if (!operations) return { playlist: {}, segment: {} };
   const playlist = {};
   const segment = {};
+  let currentSegment = 0;
   for (const op of operations) {
+    if (op.op === 'playback') {
+      currentSegment += Math.ceil(op.time / segmentLength);
+    }
     if (op.op === 'error' && op.rendition) {
       const code = op.code || 500;
-      if (op.on === 'segment') {
-        segment[op.rendition] = code;
+      if (op.on === 'segment' || (op.on !== 'playlist' && currentSegment > 0)) {
+        segment[op.rendition] = { code, activateAtSegment: currentSegment + 1 };
       } else {
         playlist[op.rendition] = code;
       }
+      currentSegment++;
     }
   }
   return { playlist, segment };

--- a/lib/logic.test.js
+++ b/lib/logic.test.js
@@ -108,22 +108,38 @@ describe('resolveRenditionErrors', () => {
     assert.deepEqual(resolveRenditionErrors(ops), { playlist: {}, segment: {} });
   });
 
-  it('puts error with no "on" field into playlist', () => {
+  it('puts error with no "on" field and no prior playback into playlist', () => {
+    const ops = [{ op: 'error', code: 404, rendition: 'low' }];
+    assert.deepEqual(resolveRenditionErrors(ops), { playlist: { low: 404 }, segment: {} });
+  });
+
+  it('converts error with no "on" field and prior playback to timed segment error', () => {
     const ops = [
       { op: 'playback', time: 30 },
       { op: 'error', code: 404, rendition: 'low' },
     ];
+    assert.deepEqual(resolveRenditionErrors(ops), { playlist: {}, segment: { low: { code: 404, activateAtSegment: 6 } } });
+  });
+
+  it('puts error with on:playlist into playlist regardless of prior playback', () => {
+    const ops = [
+      { op: 'playback', time: 30 },
+      { op: 'error', code: 404, rendition: 'low', on: 'playlist' },
+    ];
     assert.deepEqual(resolveRenditionErrors(ops), { playlist: { low: 404 }, segment: {} });
   });
 
-  it('puts error with on:playlist into playlist', () => {
-    const ops = [{ op: 'error', code: 404, rendition: 'low', on: 'playlist' }];
-    assert.deepEqual(resolveRenditionErrors(ops), { playlist: { low: 404 }, segment: {} });
-  });
-
-  it('puts error with on:segment into segment', () => {
+  it('puts error with on:segment into segment with activateAtSegment:1 when no prior playback', () => {
     const ops = [{ op: 'error', code: 503, rendition: 'mid', on: 'segment' }];
-    assert.deepEqual(resolveRenditionErrors(ops), { playlist: {}, segment: { mid: 503 } });
+    assert.deepEqual(resolveRenditionErrors(ops), { playlist: {}, segment: { mid: { code: 503, activateAtSegment: 1 } } });
+  });
+
+  it('puts error with on:segment into segment with correct activateAtSegment after playback', () => {
+    const ops = [
+      { op: 'playback', time: 18 },
+      { op: 'error', code: 404, rendition: 'low', on: 'segment' },
+    ];
+    assert.deepEqual(resolveRenditionErrors(ops), { playlist: {}, segment: { low: { code: 404, activateAtSegment: 4 } } });
   });
 
   it('defaults to 500 when no code specified', () => {
@@ -136,7 +152,7 @@ describe('resolveRenditionErrors', () => {
       { op: 'error', code: 404, rendition: 'low' },
       { op: 'error', code: 503, rendition: 'mid', on: 'segment' },
     ];
-    assert.deepEqual(resolveRenditionErrors(ops), { playlist: { low: 404 }, segment: { mid: 503 } });
+    assert.deepEqual(resolveRenditionErrors(ops), { playlist: { low: 404 }, segment: { mid: { code: 503, activateAtSegment: 2 } } });
   });
 
   it('returns empty maps for null operations', () => {

--- a/media/index.html
+++ b/media/index.html
@@ -354,7 +354,7 @@
 
   const NAMED = [
     { spec: 'example',                desc: '5s startup delay, 12s playback, then 404 error' },
-    { spec: 'abr-example',            desc: 'Mid rendition unavailable at 18s, low rendition segment errors at 24s' },
+    { spec: 'abr-example',            desc: 'Mid rendition unavailable at 12s, low rendition segment errors at 18s' },
     { spec: 'stall-and-recover',      desc: '12s playback, 8s stall, then 10s more playback' },
     { spec: 'multiple-stalls',        desc: 'Multiple rebuffer events' },
     { spec: 'network-congestion',     desc: 'Simulates a congested network at 500kbps' },

--- a/specs/abr-example.json
+++ b/specs/abr-example.json
@@ -8,9 +8,8 @@
   "operations": [
     { "op": "bandwidth", "kbps": 4000 },
     { "op": "startup", "delay": 5 },
-    { "op": "playback", "time": 18 },
+    { "op": "playback", "time": 12 },
     { "op": "error", "code": 404, "rendition": "mid" },
-    { "op": "playback", "time": 6 },
     { "op": "error", "code": 404, "rendition": "low", "on": "segment" }
   ]
 }


### PR DESCRIPTION
* Error operations on a rendition should work on the timeline (not fail immediately)