### PR TITLE
Replace ctx throw with status code

### DIFF
--- a/app.js
+++ b/app.js
@@ -249,7 +249,8 @@ async function processSegment(
 // Output
 
 function outputError(ctx, code) {
-  ctx.throw(code);
+  ctx.status = code;
+  ctx.body = null;
 }
 
 function patchM4sBuffer(buf, sequenceNumber, renditionBandwidth) {


### PR DESCRIPTION
Replace ctx throw with status code so the mocked error is not an actual process error.